### PR TITLE
Create missing index for replaying

### DIFF
--- a/src/MongoDbEventStoreAdapter.php
+++ b/src/MongoDbEventStoreAdapter.php
@@ -368,6 +368,13 @@ final class MongoDbEventStoreAdapter implements Adapter, CanHandleTransaction
                 'unique' => true,
             ]
         );
+
+        $collection->createIndex(
+            [
+                'created_at' => 1,
+                'version' => 1,
+            ]
+        );
     }
 
     /**


### PR DESCRIPTION
Quote from the MongoDB manual:

"If MongoDB cannot use an index to get documents in the requested sort order, the combined size of all documents in the sort operation, plus a small overhead, must be less than 32 megabytes."

Therefore an index has been added for the replay query.
