### PR TITLE
Add compound index for transaction_id and expire_at

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,16 +20,16 @@ before_script:
   - if [ $TRAVIS_PHP_VERSION != "7" ]; then echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
   - if [ $TRAVIS_PHP_VERSION == "7" ]; then echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
   - composer self-update
-  - composer update --prefer-dist $DEPENDENCIES
+  - composer update $DEPENDENCIES
   - if [ $TRAVIS_PHP_VERSION == "7" ]; then composer require alcaeus/mongo-php-adapter ^1.0; fi;
 
 script:
-  - phpunit --coverage-text --coverage-clover ./build/logs/clover.xml
+  - ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml
   - ./vendor/bin/php-cs-fixer fix -v --diff --dry-run
 
 after_success:
   - php vendor/bin/coveralls -v
-  
+
 notifications:
   webhooks:
     urls:

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,11 @@
         "ext-mongo": ">=1.6 for usage with mongo extension and PHP 5.x",
         "ext-mongodb": ">=1.1 for usage with mongodb extension and PHP 7"
     },
+    "config": {
+        "preferred-install": {
+            "prooph/*": "source"
+        }
+    },
     "conflict": {
         "sandrokeil/interop-config": "<1.0"
     },

--- a/src/MongoDbEventStoreAdapter.php
+++ b/src/MongoDbEventStoreAdapter.php
@@ -375,6 +375,13 @@ final class MongoDbEventStoreAdapter implements Adapter, CanHandleTransaction
                 'version' => 1,
             ]
         );
+
+        $collection->createIndex(
+            [
+                'transaction_id' => 1,
+                'expire_at' => 1,
+            ]
+        );
     }
 
     /**


### PR DESCRIPTION
This is necessary to avoid slow inserts/updates and notices from #60  are now gone.

*For the Changelog:* 
It is necessary to add this index manually to existing collection streams. Run this in your mongo shell:

```
db.[your stream collection].createIndex({"transaction_id" : 1, "expire_at" : 1})
```