### PR TITLE
Allow to disable MongoDB $isolated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7
 

--- a/src/Container/MongoDbEventStoreAdapterFactory.php
+++ b/src/Container/MongoDbEventStoreAdapterFactory.php
@@ -58,7 +58,8 @@ final class MongoDbEventStoreAdapterFactory implements RequiresConfig, RequiresM
             $config['db_name'],
             $config['write_concern'],
             $config['transaction_timeout'],
-            $config['stream_collection_map']
+            $config['stream_collection_map'],
+            !empty($config['disable_isolated']) ? true : false
         );
     }
 

--- a/tests/AbstractMongoDbEventStoreAdapterTest.php
+++ b/tests/AbstractMongoDbEventStoreAdapterTest.php
@@ -24,17 +24,17 @@ use ProophTest\EventStore\Mock\UsernameChanged;
  * Class MongoDbEventStoreAdapterTest
  * @package ProophTest\EventStore\Adapter\MongoDb
  */
-final class MongoDbEventStoreAdapterTest extends TestCase
+abstract class AbstractMongoDbEventStoreAdapterTest extends TestCase
 {
     /**
      * @var MongoDbEventStoreAdapter
      */
-    private $adapter;
+    protected $adapter;
 
     /**
      * @var \MongoClient
      */
-    private $client;
+    protected $client;
 
     protected function setUp()
     {
@@ -47,9 +47,15 @@ final class MongoDbEventStoreAdapterTest extends TestCase
             new FQCNMessageFactory(),
             new NoOpMessageConverter(),
             $this->client,
-            $dbName
+            $dbName,
+            null,
+            null,
+            [],
+            $this->disableIsolated()
         );
     }
+
+    abstract public function disableIsolated();
 
     protected function tearDown()
     {

--- a/tests/MongoDbEventStoreAdapterDisabledIsolatedTest.php
+++ b/tests/MongoDbEventStoreAdapterDisabledIsolatedTest.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * This file is part of the prooph/event-store-mongodb-adapter.
+ * (c) 2014 - 2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Date: 08/08/15 - 20:32
+ */
+
+namespace ProophTest\EventStore\Adapter\MongoDb;
+
+/**
+ * Class MongoDbEventStoreAdapterTest
+ * @package ProophTest\EventStore\Adapter\MongoDb
+ */
+final class MongoDbEventStoreAdapterDisabledIsolatedTest extends AbstractMongoDbEventStoreAdapterTest
+{
+    public function disableIsolated()
+    {
+        return true;
+    }
+}

--- a/tests/MongoDbEventStoreAdapterIsolatedTest.php
+++ b/tests/MongoDbEventStoreAdapterIsolatedTest.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * This file is part of the prooph/event-store-mongodb-adapter.
+ * (c) 2014 - 2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Date: 08/08/15 - 20:32
+ */
+
+namespace ProophTest\EventStore\Adapter\MongoDb;
+
+/**
+ * Class MongoDbEventStoreAdapterTest
+ * @package ProophTest\EventStore\Adapter\MongoDb
+ */
+final class MongoDbEventStoreAdapterIsolatedTest extends AbstractMongoDbEventStoreAdapterTest
+{
+    public function disableIsolated()
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
This is needed to [upgrade to MongoDB 4.0](https://docs.mongodb.com/manual/release-notes/4.0-compatibility/#isolated-operator). The event store works properly if disabled, because the [expire_at and transaction_id](https://github.com/prooph/event-store-mongodb-adapter/blob/master/src/MongoDbEventStoreAdapter.php#L242-L243) only removed after commit.

In another PR I plan to create a new major version of this adapter with MongoDB 4.0 and transaction support and for PHP >=7.1. No alcaeus/mongo-php-adapter lib needed anymore. So we can use MongoDB 4.0 and transaction support in "old" event store.

Any concerns about this?